### PR TITLE
ci: trusted publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4.0.0
+        uses: pnpm/action-setup@v4.1.0
 
       - name: Set node
         uses: actions/setup-node@v4
@@ -31,7 +31,7 @@ jobs:
       - run: npx changelogithub
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Dependencies
         run: pnpm i
@@ -40,10 +40,7 @@ jobs:
         run: pnpm build
 
       - name: Publish to NPM
-        run: pnpm publish --filter="!vscode-ts-macro" --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
+        run: npm i -g npm && pnpm publish --filter="!vscode-ts-macro" --access public --no-git-checks
 
       - name: Publish to VSCode
         run: pnpm run --filter="vscode-ts-macro" release


### PR DESCRIPTION
Requires @zhiyuanzmj:
- Connect GitHub repo via https://www.npmjs.com/package/ts-macro/access, and all other packages (like `@ts-macro/tsc`)
- Remove `NPM_PUBLISH_TOKEN` and `GIT_TOKEN` token in GitHub secret settings.